### PR TITLE
Added dockerfile example image in template

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+__test__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:5.12.0
+ENV PORT 3000
+ENV NODE_ENV=production
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+RUN npm install && \
+    npm run build
+EXPOSE ${PORT}
+CMD npm start

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # Boilerplate for services built with nodejs and optionally express
 Opinionated boilerplate used in Konnektid to build services in express
+
+## Build docker:
+```
+docker -t <your-image-name> .
+```
+
+## Start with docker:
+
+**build**
+
+**development**
+```
+docker run -ti --rm -p 3000:3000 --name <your-container-name> -v `pwd`/src:/usr/src/app/src -e NODE_ENV=development <your-image-name> npm run start:dev
+```
+
+**production**
+```
+docker run -P --name <your-container-name> -e NODE_ENV=production <your-image-name>
+```
+Notice that this command will expose the port defined in the Dockerfile to a random port


### PR DESCRIPTION
This PR adds `Dockerfile` and `.dockerignore` files that can be used to run the service in a container
